### PR TITLE
fix: website crashes when someone hasn't shared their socials on #share-your-socials

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -168,7 +168,7 @@ export const addProperties = (images, authors) => {
     images[i].authorid = images[i].author;
     const authorName = authors.find(
       (author) => author.authorid === images[i].authorid,
-    ).authorNick;
+    )?.authorNick ?? "Name not found";
     images[i].author = authorName;
     images[i].game = images[i].gameName;
     images[i].epochtime = images[i].epochTime;


### PR DESCRIPTION
i was turning it into the hall of fun thing for the april joke, and made it gets shots from #share-your-scraps for testing, and misty-halogen didn't post their socials (so their info aren't in authorsdb), so the `find` on authorsdb was returning `undefined` and trying to get `authorNick` from this resulted in a crash
now it returns a default string: "Name not found"