### PR TITLE
Fix custom URLs

### DIFF
--- a/src/components/SocialLinks.jsx
+++ b/src/components/SocialLinks.jsx
@@ -53,6 +53,11 @@ function getLinkIconAndLabel(link) {
 }
 
 function SocialLink({ link, ...props }) {
+  // Assume all sites are https if it's not explicitly included.
+  if (!link.startsWith("http")) {
+    link = `https://${link}`
+  }
+
   const { icon, label } = getLinkIconAndLabel(link)
 
   return (


### PR DESCRIPTION
Custom URLs don't work (they crash the entire component) if it doesn't include the scheme, so we force it to try with https.

It was needed to be fixed in both the getLinkIconAndLabel and the href so that's why it's in the main function `SocialLink`.