### PR TITLE
fix: profil banner data not cleared after changing page

### DIFF
--- a/src/pages/ImageGridContainer.jsx
+++ b/src/pages/ImageGridContainer.jsx
@@ -377,6 +377,12 @@ const ImageGridContainer = ({ pageSize, setBgImage, imageId, queryParams, onShuf
     ) : null;
   };
 
+  const handleLogoClick = () => {
+    dispatch({type: 'reset'})
+    updateQueryParam([], history);
+    setProfileData(undefined);
+  };
+
   useEffect(() => {
     if (imageData.length) {
       const filteredImages = filterImages(imageData.slice());
@@ -418,7 +424,7 @@ const ImageGridContainer = ({ pageSize, setBgImage, imageId, queryParams, onShuf
           reverseSort={isReverse}
           updateSort={handleSortChange}
           updateFormat={handleFormatChange}
-          onLogoClick={()=> dispatch({type:'reset'})}
+          onLogoClick={handleLogoClick}
           searchProps={{
             searchData,
             updateSearch: handleSearchChange,


### PR DESCRIPTION
**Please test this before merging** as it is a quick and dirty fix

When clicking on the logo it wasn't removing the banner
It also update the query params when clicking the logo now